### PR TITLE
Fix possibility of fileStat being undefined

### DIFF
--- a/utils/staticServ.js
+++ b/utils/staticServ.js
@@ -142,12 +142,18 @@ function staticService(pathname, callback) {
     let filename = safeDecodeURIComponent(path.normalize(pathname));
 
     let filePath = path.join(staticDir, pathname);
+    let fileStat;
     try {
-        let fileStat = fs.statSync(filePath);
+        fileStat = fs.statSync(filePath);
     } catch (err) {
         Logger.error(err);
 
         callback({code: 500, msg: '系统异常'});
+        return;
+    }
+
+    if (!fileStat){
+        callback({code:500, msg:'fileStat does not exist'});
         return;
     }
 


### PR DESCRIPTION
Improves the logic and exception handling for `fileStat`. Currently, workers will crash on https://github.com/youngsterxyf/redis-sentinel-ui/blob/master/utils/staticServ.js#L180.